### PR TITLE
Add the ability to customize curl options.

### DIFF
--- a/vault-hook.sh
+++ b/vault-hook.sh
@@ -9,7 +9,7 @@ SCRIPTNAME="vault-hook.sh"
 VAULT_TOKEN=""
 
 acquire_token() {
-  VAULT_TOKEN=$(curl -s -X POST \
+  VAULT_TOKEN=$(curl ${CURL_OPTS[@]} -X POST \
     -d "{\"role_id\":\"${VAULT_ROLE_ID}\",\"secret_id\":\"${VAULT_SECRET_ID}\"}" \
     "${VAULT_ADDRESS}/v1/auth/approle/login" | jq -r .auth.client_token)
 }
@@ -44,8 +44,7 @@ upload_certificate() {
 
   acquire_token
 
-  curl \
-    --silent \
+  curl ${CURL_OPTS[@]} \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     --request POST \
     -d @<( jq -n --arg cert "$(< ${CERTFILE} )" \

--- a/vault.example.inc
+++ b/vault.example.inc
@@ -3,3 +3,5 @@ VAULT_SECRET_ID="cccccccc-dddd-eeee-ffff-ggggggggggggg"
 
 VAULT_ADDRESS="https://127.0.0.1:8200"
 VAULT_SECRET_BASE="secret/ca"
+
+CURL_OPTS=(--silent --insecure --location)

--- a/vault.example.inc
+++ b/vault.example.inc
@@ -4,4 +4,4 @@ VAULT_SECRET_ID="cccccccc-dddd-eeee-ffff-ggggggggggggg"
 VAULT_ADDRESS="https://127.0.0.1:8200"
 VAULT_SECRET_BASE="secret/ca"
 
-CURL_OPTS=(--silent --insecure --location)
+CURL_OPTS=(--silent --location)


### PR DESCRIPTION
Customizing curl options without editing the
script can be useful in some cases, depending on
the used vault setup. The new option set allows
a variety of setup, like redirects and
self-signed certificates, and we can remove the
silent option for debug purposes.